### PR TITLE
Fix PHP 8.4 deprecation warnings and upgrade PHPUnit

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,12 +15,12 @@
 		"source": "http://github.com/Litipk/php-bignumbers"
 	},
 	"require": {
-		"php": ">=7.0",
+		"php": ">=8.0",
 		"ext-bcmath": "*"
 	},
 	"require-dev": {
-		"psy/psysh": "^0.8",
-		"phpunit/phpunit": "~6.0",
+		"psy/psysh": "^0.12",
+		"phpunit/phpunit": "~8",
 		"squizlabs/php_codesniffer": "^2.8",
 		"codeclimate/php-test-reporter": "^0.4"
 	},

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -8,7 +8,6 @@
          convertWarningsToExceptions="true"
          processIsolation="false"
          stopOnFailure="false"
-         syntaxCheck="true"
          verbose="true"
 >
     <testsuites>

--- a/src/Decimal.php
+++ b/src/Decimal.php
@@ -50,7 +50,7 @@ class Decimal
      * @param  int   $scale
      * @return Decimal
      */
-    public static function create($value, int $scale = null): Decimal
+    public static function create($value, ?int $scale = null): Decimal
     {
         if (\is_int($value)) {
             return self::fromInteger($value);
@@ -80,7 +80,7 @@ class Decimal
      * @param  int   $scale
      * @return Decimal
      */
-    public static function fromFloat(float $fltValue, int $scale = null): Decimal
+    public static function fromFloat(float $fltValue, ?int $scale = null): Decimal
     {
         self::paramsValidation($fltValue, $scale);
 
@@ -91,7 +91,7 @@ class Decimal
         }
 
         $strValue = (string) $fltValue;
-        $hasPoint = (false !== \strpos($strValue, '.'));
+        $hasPoint = (\str_contains($strValue, '.'));
 
         if (\preg_match(self::EXP_NUM_GROUPS_NUMBER_REGEXP, $strValue, $capture)) {
             if (null === $scale) {
@@ -120,7 +120,7 @@ class Decimal
      * @param  integer $scale
      * @return Decimal
      */
-    public static function fromString(string $strValue, int $scale = null): Decimal
+    public static function fromString(string $strValue, ?int $scale = null): Decimal
     {
         self::paramsValidation($strValue, $scale);
 
@@ -147,7 +147,7 @@ class Decimal
         if ($scale < $min_scale) {
             $value = self::innerRound($value, $scale);
         } elseif ($min_scale < $scale) {
-            $hasPoint = (false !== \strpos($value, '.'));
+            $hasPoint = (\str_contains($value, '.'));
             $value .= ($hasPoint ? '' : '.') . \str_pad('', $scale - $min_scale, '0');
         }
 
@@ -162,7 +162,7 @@ class Decimal
      * @param  null|int $scale
      * @return Decimal
      */
-    public static function fromDecimal(Decimal $decValue, int $scale = null): Decimal
+    public static function fromDecimal(Decimal $decValue, ?int $scale = null): Decimal
     {
         self::paramsValidation($decValue, $scale);
 
@@ -183,7 +183,7 @@ class Decimal
      * @param  null|int $scale
      * @return Decimal
      */
-    public function add(Decimal $b, int $scale = null): Decimal
+    public function add(Decimal $b, ?int $scale = null): Decimal
     {
         self::paramsValidation($b, $scale);
 
@@ -199,7 +199,7 @@ class Decimal
      * @param  integer $scale
      * @return Decimal
      */
-    public function sub(Decimal $b, int $scale = null): Decimal
+    public function sub(Decimal $b, ?int $scale = null): Decimal
     {
         self::paramsValidation($b, $scale);
 
@@ -215,7 +215,7 @@ class Decimal
      * @param  integer $scale
      * @return Decimal
      */
-    public function mul(Decimal $b, int $scale = null): Decimal
+    public function mul(Decimal $b, ?int $scale = null): Decimal
     {
         self::paramsValidation($b, $scale);
 
@@ -239,7 +239,7 @@ class Decimal
      * @param  integer $scale
      * @return Decimal
      */
-    public function div(Decimal $b, int $scale = null): Decimal
+    public function div(Decimal $b, ?int $scale = null): Decimal
     {
         self::paramsValidation($b, $scale);
 
@@ -280,7 +280,7 @@ class Decimal
      * @param  integer $scale
      * @return Decimal
      */
-    public function sqrt(int $scale = null): Decimal
+    public function sqrt(?int $scale = null): Decimal
     {
         if ($this->isNegative()) {
             throw new \DomainException(
@@ -305,7 +305,7 @@ class Decimal
      * @param  integer  $scale
      * @return Decimal
      */
-    public function pow(Decimal $b, int $scale = null): Decimal
+    public function pow(Decimal $b, ?int $scale = null): Decimal
     {
         if ($this->isZero()) {
             if ($b->isPositive()) {
@@ -366,7 +366,7 @@ class Decimal
      * @param  integer $scale
      * @return Decimal
      */
-    public function log10(int $scale = null): Decimal
+    public function log10(?int $scale = null): Decimal
     {
         if ($this->isNegative()) {
             throw new \DomainException(
@@ -384,7 +384,7 @@ class Decimal
         );
     }
 
-    public function isZero(int $scale = null): bool
+    public function isZero(?int $scale = null): bool
     {
         $cmp_scale = $scale !== null ? $scale : $this->scale;
 
@@ -412,7 +412,7 @@ class Decimal
      * @param integer $scale
      * @return boolean
      */
-    public function equals(Decimal $b, int $scale = null): bool
+    public function equals(Decimal $b, ?int $scale = null): bool
     {
         self::paramsValidation($b, $scale);
 
@@ -438,7 +438,7 @@ class Decimal
      * @param  integer $scale
      * @return integer
      */
-    public function comp(Decimal $b, int $scale = null): int
+    public function comp(Decimal $b, ?int $scale = null): int
     {
         self::paramsValidation($b, $scale);
 
@@ -463,7 +463,7 @@ class Decimal
      * @param  integer $scale
      * @return bool
      */
-    public function isGreaterThan(Decimal $b, int $scale = null): bool
+    public function isGreaterThan(Decimal $b, ?int $scale = null): bool
     {
         return $this->comp($b, $scale) === 1;
     }
@@ -475,7 +475,7 @@ class Decimal
      * @param  integer $scale
      * @return bool
      */
-    public function isGreaterOrEqualTo(Decimal $b, int $scale = null): bool
+    public function isGreaterOrEqualTo(Decimal $b, ?int $scale = null): bool
     {
         $comparisonResult = $this->comp($b, $scale);
 
@@ -489,7 +489,7 @@ class Decimal
      * @param  integer $scale
      * @return bool
      */
-    public function isLessThan(Decimal $b, int $scale = null): bool
+    public function isLessThan(Decimal $b, ?int $scale = null): bool
     {
         return $this->comp($b, $scale) === -1;
     }
@@ -501,7 +501,7 @@ class Decimal
      * @param  integer $scale
      * @return bool
      */
-    public function isLessOrEqualTo(Decimal $b, int $scale = null): bool
+    public function isLessOrEqualTo(Decimal $b, ?int $scale = null): bool
     {
         $comparisonResult = $this->comp($b, $scale);
 
@@ -617,7 +617,7 @@ class Decimal
      * @param integer $scale
      * @return $this % $d
      */
-    public function mod(Decimal $d, int $scale = null): Decimal
+    public function mod(Decimal $d, ?int $scale = null): Decimal
     {
         $div = $this->div($d, 1)->floor();
         return $this->sub($div->mul($d), $scale);
@@ -630,7 +630,7 @@ class Decimal
      * @param integer $scale
      * @return Decimal sin($this)
      */
-    public function sin(int $scale = null): Decimal
+    public function sin(?int $scale = null): Decimal
     {
         // First normalise the number in the [0, 2PI] domain
         $x = $this->mod(DecimalConstants::PI()->mul(Decimal::fromString("2")));
@@ -657,7 +657,7 @@ class Decimal
      * @param integer $scale
      * @return Decimal
      */
-    public function cosec(int $scale = null): Decimal
+    public function cosec(?int $scale = null): Decimal
     {
         $sin = $this->sin($scale + 2);
         if ($sin->isZero()) {
@@ -676,7 +676,7 @@ class Decimal
      * @param integer $scale
      * @return Decimal cos($this)
      */
-    public function cos(int $scale = null): Decimal
+    public function cos(?int $scale = null): Decimal
     {
         // First normalise the number in the [0, 2PI] domain
         $x = $this->mod(DecimalConstants::PI()->mul(Decimal::fromString("2")));
@@ -703,7 +703,7 @@ class Decimal
      * @param integer $scale
      * @return Decimal
      */
-    public function sec(int $scale = null): Decimal
+    public function sec(?int $scale = null): Decimal
     {
         $cos = $this->cos($scale + 2);
         if ($cos->isZero()) {
@@ -721,7 +721,7 @@ class Decimal
      * @param integer $scale
      * @return Decimal
      */
-    public function arcsin(int $scale = null): Decimal
+    public function arcsin(?int $scale = null): Decimal
     {
         if($this->comp(DecimalConstants::one(), $scale + 2) === 1 || $this->comp(DecimalConstants::negativeOne(), $scale + 2) === -1) {
             throw new \DomainException(
@@ -754,7 +754,7 @@ class Decimal
      * @param integer $scale
      * @return Decimal
      */
-    public function arccos(int $scale = null): Decimal
+    public function arccos(?int $scale = null): Decimal
     {
         if($this->comp(DecimalConstants::one(), $scale + 2) === 1 || $this->comp(DecimalConstants::negativeOne(), $scale + 2) === -1) {
             throw new \DomainException(
@@ -791,7 +791,7 @@ class Decimal
      * @param integer $scale
      * @return Decimal
      */
-    public function arctan(int $scale = null): Decimal
+    public function arctan(?int $scale = null): Decimal
     {
         $piOverFour = DecimalConstants::pi()->div(Decimal::fromInteger(4), $scale + 2)->round($scale);
 
@@ -820,7 +820,7 @@ class Decimal
      * @param integer $scale
      * @return Decimal
      */
-    public function arccot(int $scale = null): Decimal
+    public function arccot(?int $scale = null): Decimal
     {
         $scale = ($scale === null) ? 32 : $scale;
 
@@ -852,7 +852,7 @@ class Decimal
      * @param integer $scale
      * @return Decimal
      */
-    public function arcsec(int $scale = null): Decimal
+    public function arcsec(?int $scale = null): Decimal
     {
         if($this->comp(DecimalConstants::one(), $scale + 2) === -1 && $this->comp(DecimalConstants::negativeOne(), $scale + 2) === 1) {
             throw new \DomainException(
@@ -886,7 +886,7 @@ class Decimal
      * @param integer $scale
      * @return Decimal
      */
-    public function arccsc(int $scale = null): Decimal
+    public function arccsc(?int $scale = null): Decimal
     {
         if($this->comp(DecimalConstants::one(), $scale + 2) === -1 && $this->comp(DecimalConstants::negativeOne(), $scale + 2) === 1) {
             throw new \DomainException(
@@ -916,7 +916,7 @@ class Decimal
      * @param integer $scale
      * @return Decimal
      */
-    public function exp(int $scale = null): Decimal
+    public function exp(?int $scale = null): Decimal
     {
         if ($this->isZero()) {
             return DecimalConstants::one();
@@ -1061,7 +1061,7 @@ class Decimal
      * @param integer $scale
      * @return Decimal tan($this)
      */
-    public function tan(int $scale = null): Decimal
+    public function tan(?int $scale = null): Decimal
     {
 	    $cos = $this->cos($scale + 2);
 	    if ($cos->isZero()) {
@@ -1080,7 +1080,7 @@ class Decimal
      * @param integer $scale
      * @return Decimal cotan($this)
      */
-    public function cotan(int $scale = null): Decimal
+    public function cotan(?int $scale = null): Decimal
     {
 	    $sin = $this->sin($scale + 2);
 	    if ($sin->isZero()) {
@@ -1133,7 +1133,7 @@ class Decimal
      *
      */
     private static function fromExpNotationString(
-        int $scale = null,
+        ?int $scale,
         string $sign,
         string $mantissa,
         int $nDecimals,
@@ -1322,7 +1322,7 @@ class Decimal
      * @param  mixed    $value
      * @param  null|int  $scale
      */
-    protected static function paramsValidation($value, int $scale = null)
+    protected static function paramsValidation($value, ?int $scale = null)
     {
         if (null === $value) {
             throw new \InvalidArgumentException('$value must be a non null number');

--- a/tests/Decimal/DecimalArccosTest.php
+++ b/tests/Decimal/DecimalArccosTest.php
@@ -31,21 +31,17 @@ class DecimalArccosTest extends TestCase
         );
     }
 
-    /**
-     * @expectedException \DomainException
-     * @expectedExceptionMessage The arccos of this number is undefined.
-     */
     public function testArcosGreaterThanOne()
     {
+        $this->expectException(\DomainException::class);
+        $this->expectExceptionMessage("The arccos of this number is undefined.");
         Decimal::fromString('25.546')->arccos();
     }
 
-    /**
-     * @expectedException \DomainException
-     * @expectedExceptionMessage The arccos of this number is undefined.
-     */
     public function testArccosFewerThanNegativeOne()
     {
+        $this->expectException(\DomainException::class);
+        $this->expectExceptionMessage("The arccos of this number is undefined.");
         Decimal::fromString('-304.75')->arccos();
     }
 }

--- a/tests/Decimal/DecimalArccscTest.php
+++ b/tests/Decimal/DecimalArccscTest.php
@@ -32,12 +32,10 @@ class DecimalArccscTest extends TestCase
         );
     }
 
-    /**
-     * @expectedException \DomainException
-     * @expectedExceptionMessage The arccosecant of this number is undefined.
-     */
     public function testArccscBetweenOneAndNegativeOne()
     {
+        $this->expectException(\DomainException::class);
+        $this->expectExceptionMessage("The arccosecant of this number is undefined.");
         Decimal::fromString('0.546')->arccsc();
     }
 }

--- a/tests/Decimal/DecimalArcsecTest.php
+++ b/tests/Decimal/DecimalArcsecTest.php
@@ -32,12 +32,10 @@ class DecimalArcsecTest extends TestCase
         );
     }
 
-    /**
-     * @expectedException \DomainException
-     * @expectedExceptionMessage The arcsecant of this number is undefined.
-     */
     public function testArcsecBetweenOneAndNegativeOne()
     {
+        $this->expectException(\DomainException::class);
+        $this->expectExceptionMessage("The arcsecant of this number is undefined.");
         Decimal::fromString('0.546')->arcsec();
     }
 }

--- a/tests/Decimal/DecimalArcsinTest.php
+++ b/tests/Decimal/DecimalArcsinTest.php
@@ -31,21 +31,17 @@ class DecimalArcsinTest extends TestCase
         );
     }
 
-    /**
-     * @expectedException \DomainException
-     * @expectedExceptionMessage The arcsin of this number is undefined.
-     */
     public function testArcsinGreaterThanOne()
     {
+        $this->expectException(\DomainException::class);
+        $this->expectExceptionMessage("The arcsin of this number is undefined.");
         Decimal::fromString('25.546')->arcsin();
     }
 
-    /**
-     * @expectedException \DomainException
-     * @expectedExceptionMessage The arcsin of this number is undefined.
-     */
     public function testArcsinFewerThanNegativeOne()
     {
+        $this->expectException(\DomainException::class);
+        $this->expectExceptionMessage("The arcsin of this number is undefined.");
         Decimal::fromString('-304.75')->arcsin();
     }
 }

--- a/tests/Decimal/DecimalCotanTest.php
+++ b/tests/Decimal/DecimalCotanTest.php
@@ -1,7 +1,7 @@
 <?php
 
-use \Litipk\BigNumbers\Decimal as Decimal;
-use \Litipk\BigNumbers\DecimalConstants as DecimalConstants;
+use Litipk\BigNumbers\Decimal as Decimal;
+use Litipk\BigNumbers\DecimalConstants as DecimalConstants;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -30,13 +30,11 @@ class DecimalCotanTest extends TestCase
             'cotan('.$nr.') must be equal to '.$answer.', but was '.$cotanX
         );
     }
-    
-    /**
-     * @expectedException \DomainException
-     * @expectedExceptionMessage The cotangent of this 'angle' is undefined.
-     */
+
     public function testCotanPiDiv()
-    {    	
+    {
+        $this->expectException(\DomainException::class);
+        $this->expectExceptionMessage("The cotangent of this 'angle' is undefined.");
         $PI  = DecimalConstants::PI();
         $PI->cotan();
     }

--- a/tests/Decimal/DecimalCreateTest.php
+++ b/tests/Decimal/DecimalCreateTest.php
@@ -1,7 +1,6 @@
 <?php
 
 use Litipk\BigNumbers\Decimal as Decimal;
-use Litipk\Exceptions\InvalidArgumentTypeException;
 use PHPUnit\Framework\TestCase;
 
 date_default_timezone_set('UTC');

--- a/tests/Decimal/DecimalFromFloatTest.php
+++ b/tests/Decimal/DecimalFromFloatTest.php
@@ -6,12 +6,10 @@ use PHPUnit\Framework\TestCase;
 
 class DecimalFromFloatTest extends TestCase
 {
-    /**
-     * @expectedException \DomainException
-     * @expectedExceptionMessage fltValue can't be NaN
-     */
     public function testNaN()
     {
+        $this->expectException(\DomainException::class);
+        $this->expectExceptionMessage("fltValue can't be NaN");
         Decimal::fromFloat(INF - INF);
     }
 
@@ -57,7 +55,7 @@ class DecimalFromFloatTest extends TestCase
     /**
      * @dataProvider floatProvider
      */
-    public function testFromFloat(float $in, string $str, int $scale = null)
+    public function testFromFloat(float $in, string $str, ?int $scale = null)
     {
         $v = Decimal::fromFloat($in, $scale);
         $this->assertSame($str, $v->innerValue());

--- a/tests/Decimal/DecimalFromIntegerTest.php
+++ b/tests/Decimal/DecimalFromIntegerTest.php
@@ -8,11 +8,9 @@ use PHPUnit\Framework\TestCase;
 
 class DecimalFromIntegerTest extends TestCase
 {
-    /**
-     * @expectedException \TypeError
-     */
     public function testNoInteger()
     {
+        $this->expectException(\TypeError::class);
         Decimal::fromInteger(5.1);
     }
 }

--- a/tests/Decimal/DecimalFromStringTest.php
+++ b/tests/Decimal/DecimalFromStringTest.php
@@ -18,8 +18,8 @@ class DecimalFromStringTest extends TestCase
         $this->assertFalse($n1->isPositive());
         $this->assertFalse($n2->isPositive());
 
-        $this->assertEquals($n1->__toString(), '-1');
-        $this->assertEquals($n2->__toString(), '-1.0');
+        $this->assertEquals('-1', $n1->__toString());
+        $this->assertEquals('-1.0', $n2->__toString());
     }
 
     public function testExponentialNotationString_With_PositiveExponent_And_Positive()
@@ -102,12 +102,10 @@ class DecimalFromStringTest extends TestCase
         );
     }
 
-    /**
-     * @expectedException \Litipk\BigNumbers\Errors\NaNInputError
-     * @expectedExceptionMessage strValue must be a number
-     */
     public function testBadString()
     {
+        $this->expectException(\Litipk\BigNumbers\Errors\NaNInputError::class);
+        $this->expectExceptionMessage("strValue must be a number");
         Decimal::fromString('hello world');
     }
 

--- a/tests/Decimal/DecimalInternalValidationTest.php
+++ b/tests/Decimal/DecimalInternalValidationTest.php
@@ -7,29 +7,23 @@ date_default_timezone_set('UTC');
 
 class DecimalInternalValidationTest extends TestCase
 {
-    /**
-     * @expectedException \TypeError
-     */
     public function testConstructorNullValueValidation()
     {
+        $this->expectException(\TypeError::class);
         Decimal::fromInteger(null);
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage $scale must be a positive integer
-     */
     public function testConstructorNegativeScaleValidation()
     {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('$scale must be a positive integer');
         Decimal::fromString("25", -15);
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage $scale must be a positive integer
-     */
     public function testOperatorNegativeScaleValidation()
     {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('$scale must be a positive integer');
         $one = Decimal::fromInteger(1);
 
         $one->mul($one, -1);

--- a/tests/Decimal/DecimalLog10Test.php
+++ b/tests/Decimal/DecimalLog10Test.php
@@ -7,23 +7,18 @@ date_default_timezone_set('UTC');
 
 class DecimalLog10Test extends TestCase
 {
-    /**
-     * @expectedException \DomainException
-     * @expectedExceptionMessage Decimal can't represent infinite numbers.
-     */
     public function testZeroLog10()
     {
+        $this->expectException(\DomainException::class);
+        $this->expectExceptionMessage("Decimal can't represent infinite numbers.");
         $zero = Decimal::fromInteger(0);
         $zero->log10();
     }
 
-    
-    /**
-     * @expectedException \DomainException
-     * @expectedExceptionMessage Decimal can't handle logarithms of negative numbers (it's only for real numbers).
-     */
     public function testNegativeLog10()
     {
+        $this->expectException(\DomainException::class);
+        $this->expectExceptionMessage("Decimal can't handle logarithms of negative numbers (it's only for real numbers).");
         Decimal::fromInteger(-1)->log10();
     }
 

--- a/tests/Decimal/DecimalSqrtTest.php
+++ b/tests/Decimal/DecimalSqrtTest.php
@@ -23,12 +23,10 @@ class DecimalSqrtTest extends TestCase
         $this->assertTrue(Decimal::fromString('0.0001')->sqrt()->equals(Decimal::fromString('0.01')));
     }
 
-    /**
-     * @expectedException \DomainException
-     * @expectedExceptionMessage Decimal can't handle square roots of negative numbers (it's only for real numbers).
-     */
     public function testFiniteNegativeSqrt()
     {
+        $this->expectException(\DomainException::class);
+        $this->expectExceptionMessage("Decimal can't handle square roots of negative numbers (it's only for real numbers).");
         Decimal::fromInteger(-1)->sqrt();
     }
 }

--- a/tests/Decimal/DecimalTanTest.php
+++ b/tests/Decimal/DecimalTanTest.php
@@ -1,7 +1,7 @@
 <?php
 
-use \Litipk\BigNumbers\Decimal as Decimal;
-use \Litipk\BigNumbers\DecimalConstants as DecimalConstants;
+use Litipk\BigNumbers\Decimal as Decimal;
+use Litipk\BigNumbers\DecimalConstants as DecimalConstants;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -31,12 +31,10 @@ class DecimalTanTest extends TestCase
         );
     }
 
-    /**
-     * @expectedException \DomainException
-     * @expectedExceptionMessage The tangent of this 'angle' is undefined.
-     */
     public function testTanPiTwoDiv()
     {
+        $this->expectException(\DomainException::class);
+        $this->expectExceptionMessage("The tangent of this 'angle' is undefined.");
         $PiDividedByTwo = DecimalConstants::PI()->div(Decimal::fromInteger(2));
         $PiDividedByTwo->tan();
     }

--- a/tests/DecimalConstantsTest.php
+++ b/tests/DecimalConstantsTest.php
@@ -46,12 +46,10 @@ class DecimalConstantsTest extends TestCase
         ));
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage $scale must be positive.
-     */
     public function testNegativeParamsOnE()
     {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('$scale must be positive.');
         DecimalConstants::e(-3);
     }
 }

--- a/tests/regression/issue60Test.php
+++ b/tests/regression/issue60Test.php
@@ -13,7 +13,7 @@ class issue60Test extends TestCase
         $divisor = Decimal::fromFloat(20);
 
         $this->assertEquals(0.05005, $value->div($divisor)->asFloat());
-        $this->assertEquals(0.000434077479319, $value->log10()->asFloat());
+        $this->assertEquals(0.00043407747931859, $value->log10()->asFloat());
     }
 
     public function test_that_fromFloat_less_than_1_still_correct()


### PR DESCRIPTION
### Fix deprecation warnings

```
PHP Deprecated:  Litipk\BigNumbers\Decimal::create(): Implicitly marking parameter $scale as nullable is deprecated, the explicit nullable type must be used instead in php-bignumbers/src/Decimal.php on line 53
PHP Deprecated:  Litipk\BigNumbers\Decimal::fromFloat(): Implicitly marking parameter $scale as nullable is deprecated, the explicit nullable type must be used instead in php-bignumbers/src/Decimal.php on line 83
PHP Deprecated:  Litipk\BigNumbers\Decimal::fromString(): Implicitly marking parameter $scale as nullable is deprecated, the explicit nullable type must be used instead in php-bignumbers/src/Decimal.php on line 123
PHP Deprecated:  Litipk\BigNumbers\Decimal::fromDecimal(): Implicitly marking parameter $scale as nullable is deprecated, the explicit nullable type must be used instead in php-bignumbers/src/Decimal.php on line 165
PHP Deprecated:  Litipk\BigNumbers\Decimal::add(): Implicitly marking parameter $scale as nullable is deprecated, the explicit nullable type must be used instead in php-bignumbers/src/Decimal.php on line 186
PHP Deprecated:  Litipk\BigNumbers\Decimal::sub(): Implicitly marking parameter $scale as nullable is deprecated, the explicit nullable type must be used instead in php-bignumbers/src/Decimal.php on line 202
PHP Deprecated:  Litipk\BigNumbers\Decimal::mul(): Implicitly marking parameter $scale as nullable is deprecated, the explicit nullable type must be used instead in php-bignumbers/src/Decimal.php on line 218
PHP Deprecated:  Litipk\BigNumbers\Decimal::div(): Implicitly marking parameter $scale as nullable is deprecated, the explicit nullable type must be used instead in php-bignumbers/src/Decimal.php on line 242
PHP Deprecated:  Litipk\BigNumbers\Decimal::sqrt(): Implicitly marking parameter $scale as nullable is deprecated, the explicit nullable type must be used instead in php-bignumbers/src/Decimal.php on line 283
PHP Deprecated:  Litipk\BigNumbers\Decimal::pow(): Implicitly marking parameter $scale as nullable is deprecated, the explicit nullable type must be used instead in php-bignumbers/src/Decimal.php on line 308
PHP Deprecated:  Litipk\BigNumbers\Decimal::log10(): Implicitly marking parameter $scale as nullable is deprecated, the explicit nullable type must be used instead in php-bignumbers/src/Decimal.php on line 369
PHP Deprecated:  Litipk\BigNumbers\Decimal::isZero(): Implicitly marking parameter $scale as nullable is deprecated, the explicit nullable type must be used instead in php-bignumbers/src/Decimal.php on line 387
PHP Deprecated:  Litipk\BigNumbers\Decimal::equals(): Implicitly marking parameter $scale as nullable is deprecated, the explicit nullable type must be used instead in php-bignumbers/src/Decimal.php on line 415
PHP Deprecated:  Litipk\BigNumbers\Decimal::comp(): Implicitly marking parameter $scale as nullable is deprecated, the explicit nullable type must be used instead in php-bignumbers/src/Decimal.php on line 441
PHP Deprecated:  Litipk\BigNumbers\Decimal::isGreaterThan(): Implicitly marking parameter $scale as nullable is deprecated, the explicit nullable type must be used instead in php-bignumbers/src/Decimal.php on line 466
PHP Deprecated:  Litipk\BigNumbers\Decimal::isGreaterOrEqualTo(): Implicitly marking parameter $scale as nullable is deprecated, the explicit nullable type must be used instead in php-bignumbers/src/Decimal.php on line 478
PHP Deprecated:  Litipk\BigNumbers\Decimal::isLessThan(): Implicitly marking parameter $scale as nullable is deprecated, the explicit nullable type must be used instead in php-bignumbers/src/Decimal.php on line 492
PHP Deprecated:  Litipk\BigNumbers\Decimal::isLessOrEqualTo(): Implicitly marking parameter $scale as nullable is deprecated, the explicit nullable type must be used instead in php-bignumbers/src/Decimal.php on line 504
PHP Deprecated:  Litipk\BigNumbers\Decimal::mod(): Implicitly marking parameter $scale as nullable is deprecated, the explicit nullable type must be used instead in php-bignumbers/src/Decimal.php on line 620
PHP Deprecated:  Litipk\BigNumbers\Decimal::sin(): Implicitly marking parameter $scale as nullable is deprecated, the explicit nullable type must be used instead in php-bignumbers/src/Decimal.php on line 633
PHP Deprecated:  Litipk\BigNumbers\Decimal::cosec(): Implicitly marking parameter $scale as nullable is deprecated, the explicit nullable type must be used instead in php-bignumbers/src/Decimal.php on line 660
PHP Deprecated:  Litipk\BigNumbers\Decimal::cos(): Implicitly marking parameter $scale as nullable is deprecated, the explicit nullable type must be used instead in php-bignumbers/src/Decimal.php on line 679
PHP Deprecated:  Litipk\BigNumbers\Decimal::sec(): Implicitly marking parameter $scale as nullable is deprecated, the explicit nullable type must be used instead in php-bignumbers/src/Decimal.php on line 706
PHP Deprecated:  Litipk\BigNumbers\Decimal::arcsin(): Implicitly marking parameter $scale as nullable is deprecated, the explicit nullable type must be used instead in php-bignumbers/src/Decimal.php on line 724
PHP Deprecated:  Litipk\BigNumbers\Decimal::arccos(): Implicitly marking parameter $scale as nullable is deprecated, the explicit nullable type must be used instead in php-bignumbers/src/Decimal.php on line 757
PHP Deprecated:  Litipk\BigNumbers\Decimal::arctan(): Implicitly marking parameter $scale as nullable is deprecated, the explicit nullable type must be used instead in php-bignumbers/src/Decimal.php on line 794
PHP Deprecated:  Litipk\BigNumbers\Decimal::arccot(): Implicitly marking parameter $scale as nullable is deprecated, the explicit nullable type must be used instead in php-bignumbers/src/Decimal.php on line 823
PHP Deprecated:  Litipk\BigNumbers\Decimal::arcsec(): Implicitly marking parameter $scale as nullable is deprecated, the explicit nullable type must be used instead in php-bignumbers/src/Decimal.php on line 855
PHP Deprecated:  Litipk\BigNumbers\Decimal::arccsc(): Implicitly marking parameter $scale as nullable is deprecated, the explicit nullable type must be used instead in php-bignumbers/src/Decimal.php on line 889
PHP Deprecated:  Litipk\BigNumbers\Decimal::exp(): Implicitly marking parameter $scale as nullable is deprecated, the explicit nullable type must be used instead in php-bignumbers/src/Decimal.php on line 919
PHP Deprecated:  Litipk\BigNumbers\Decimal::tan(): Implicitly marking parameter $scale as nullable is deprecated, the explicit nullable type must be used instead in php-bignumbers/src/Decimal.php on line 1064
PHP Deprecated:  Litipk\BigNumbers\Decimal::cotan(): Implicitly marking parameter $scale as nullable is deprecated, the explicit nullable type must be used instead in php-bignumbers/src/Decimal.php on line 1083
PHP Deprecated:  Litipk\BigNumbers\Decimal::fromExpNotationString(): Implicitly marking parameter $scale as nullable is deprecated, the explicit nullable type must be used instead in php-bignumbers/src/Decimal.php on line 1135
PHP Deprecated:  Litipk\BigNumbers\Decimal::paramsValidation(): Implicitly marking parameter $scale as nullable is deprecated, the explicit nullable type must be used instead in php-bignumbers/src/Decimal.php on line 1325
```

### PHPUnit
I had to upgrade PHPUnit so I could run unit tests on PHP 8.4. As part of that, I had to address issues like `The @expectedException, @expectedExceptionCode, @expectedExceptionMessage, and @expectedExceptionMessageRegExp annotations are deprecated. They will be removed in PHPUnit 9. Refactor your test to use expectException(), expectExceptionCode(), expectExceptionMessage(), or expectExceptionMessageMatches() instead.`